### PR TITLE
Fixed 'mode' attribute & readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ See `app/index.html` in the respository.
   var myapp = angular.module('myapp', ['ngPasswordStrength'])
   ```
 
-4. Add ng-password-strength directive to the wanted element, example:
+4. Add ng-password-strength directive to the wanted element & a scope variable to the strength attribute, example:
   ```html
-  <div ng-password-strength="pass"> .... </div>
+  <div ng-password-strength="pass" strength="pass_strength"> .... </div>
   ```
 
 * Accepted addtional params:
 
-  * strength: value returned [0-100]
   * mode: 'foundation' or 'bootstrap'. Sets inner-class, inner-class-prefix, outter-class-prefix. No need to set one by one
   * inner-class: inner bar class (i.e. 'progress-bar')
   * inner-class-prefix: inner bar class prefix (i.e. 'progress-bar-' => 'progress-bar-success')

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See `app/index.html` in the respository.
 
 * Accepted addtional params:
 
-  * mode: 'foundation' or 'bootstrap'. Sets inner-class, inner-class-prefix, outter-class-prefix. No need to set one by one
+  * mode: 'foundation', 'bootstrap' or 'custom' (for custom styling). Sets inner-class, inner-class-prefix, outter-class-prefix, no need to set one by one. Defaults to 'bootstrap'.
   * inner-class: inner bar class (i.e. 'progress-bar')
   * inner-class-prefix: inner bar class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
   * outter-class-prefix: root element class prefix (i.e. 'progress-bar-' => 'progress-bar-success')

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See `app/index.html` in the respository.
 
 * Accepted addtional params:
 
-  * mode: 'foundation', 'bootstrap' or 'custom' (for custom styling). Sets inner-class, inner-class-prefix, outter-class-prefix, no need to set one by one. Defaults to 'bootstrap'.
+  * mode: 'foundation', 'bootstrap' or 'custom' (for custom styling). Sets inner-class, inner-class-prefix, outter-class-prefix, no need to set one by one. Defaults to 'bootstrap' if not specified.
   * inner-class: inner bar class (i.e. 'progress-bar')
   * inner-class-prefix: inner bar class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
   * outter-class-prefix: root element class prefix (i.e. 'progress-bar-' => 'progress-bar-success')

--- a/app/scripts/directives/ng-password-strength.js
+++ b/app/scripts/directives/ng-password-strength.js
@@ -210,11 +210,11 @@
             scope.$watch('mode', function() {
               scope.mode = scope.mode || 'bootstrap';   //If mode is not defined then default to bootstrap
 
-              if(scope.mode === 'custom'){    //If custom is set as the mode then dont apply any class
+              if(scope.mode === 'bootstrap' || scope.mode === 'foundation'){    //If bootstrap or foundation mode then apply the classes
+                angular.extend(scope, modes[scope.mode]);
                 return;
               }
 
-              angular.extend(scope, modes[scope.mode]);
               scope.valueClass = getClass(scope.value);
             });
 

--- a/app/scripts/directives/ng-password-strength.js
+++ b/app/scripts/directives/ng-password-strength.js
@@ -21,9 +21,11 @@
             innerClassPrefix: '@?',
             outterClassPrefix: '@?',
             innerClass: '@?',
-            mode: '=?'
+            mode: '@?'  //Mode is set via attribute
           },
           link: function(scope /*, elem, attrs*/ ) {
+            scope.value = scope.value || measureStrength(scope.pwd);
+            
             var modes = {
                 foundation: {
                   innerClass: 'meter'
@@ -206,6 +208,12 @@
 
 
             scope.$watch('mode', function() {
+              scope.mode = scope.mode || 'bootstrap';   //If mode is not defined then default to bootstrap
+
+              if(scope.mode === 'custom'){    //If custom is set as the mode then dont apply any class
+                return;
+              }
+
               angular.extend(scope, modes[scope.mode]);
               scope.valueClass = getClass(scope.value);
             });
@@ -214,6 +222,7 @@
               scope.value = measureStrength(scope.pwd);
               scope.valueClass = getClass(scope.value);
             });
+
           },
         };
       });


### PR DESCRIPTION
1. The mode attribute was not working irrespective of the attribute added and configured in the template. Binding switched to '@?'.  Working fine now.

2. If no mode is specified then defaults to 'bootstrap'. Moreover if mode is set as 'custom' then custom classes are not applied, actually you give anything apart from bootstrap or foundation, classes will not be applied.

3. 'strength' attribute is compulsory to provide, without which angular js gives error. http://errors.angularjs.org/1.3.14/$compile/nonassign?p0=undefined&p1=ngPasswordStrength

I have updated readme to add strength to the sample and description about mode is updated.

Please review them.
