### PR TITLE
Fix match to escape RegExp characters

### DIFF
--- a/app/src/services/password-strength-formula.factory.js
+++ b/app/src/services/password-strength-formula.factory.js
@@ -16,7 +16,13 @@
             getStrength: getStrength
         };
 
-
+        /**
+         * Escape RegExp characters
+         * @param {String} str - chars to be escaped
+         */
+        function escapeRegChars(str) {
+            return str.replace(/[-[\]\/{}()*+?.^$|]/g, "\\$&");
+        };
 
         /////////////////////////////
 
@@ -119,7 +125,7 @@
                 var arr = _p.split('');
                 counts.neg.repeated = 0;
                 for (i = 0; i < arr.length; i++) {
-                    var _reg = new RegExp(_p[i], 'g');
+                    var _reg = new RegExp(escapeRegChars(_p[i]), 'g');
                     var cnt = _p.match(_reg).length;
                     if (cnt > 1 && !repeats[_p[i]]) {
                         repeats[_p[i]] = cnt;


### PR DESCRIPTION
Avoid special characters from breaking the regex expression by escaping them.

Closes #30 