### PR TITLE
Add capability for setting the class for a low|moderate|high password strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ See `app/index.html` in the respository.
   * inner-class: inner bar class (i.e. 'progress-bar')
   * inner-class-prefix: inner bar class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
   * outter-class-prefix: root element class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
-  * low-strength-class: inner bar class for showing a low password strength (i.e. 'my-danger-class'), default: 'danger'
-  * middle-strength-class: inner bar class for showing a moderate password strength (i.e. 'my-warning-class'), default: 'warning'
-  * high-strength-class: inner bar class for showing a high password strength (i.e. 'my-success-class'), default: 'success'
+  * inner-low-strength-class: inner bar class for showing a low password strength (i.e. 'my-danger-class'), default: 'danger'
+  * outter-low-strength-class: outter bar class for showing a low password strength (i.e. 'my-danger-class'), default: 'danger'
+  * inner-middle-strength-class: inner bar class for showing a moderate password strength (i.e. 'my-warning-class'), default: 'warning'
+  * outter-middle-strength-class: outter bar class for showing a moderate password strength (i.e. 'my-warning-class'), default: 'warning'
+  * inner-high-strength-class: inner bar class for showing a high password strength (i.e. 'my-success-class'), default: 'success'
+  * outter-high-strength-class: outter bar class for showing a high password strength (i.e. 'my-success-class'), default: 'success'
 
   * calculation-mode: 'formula' (default) or 'entropy'. Formula is explained below
   * goal: only used in entropy mode. Fixes the amount to reach. Default: 96

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ See `app/index.html` in the respository.
   * inner-class: inner bar class (i.e. 'progress-bar')
   * inner-class-prefix: inner bar class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
   * outter-class-prefix: root element class prefix (i.e. 'progress-bar-' => 'progress-bar-success')
+  * low-strength-class: inner bar class for showing a low password strength (i.e. 'my-danger-class'), default: 'danger'
+  * middle-strength-class: inner bar class for showing a moderate password strength (i.e. 'my-warning-class'), default: 'warning'
+  * high-strength-class: inner bar class for showing a high password strength (i.e. 'my-success-class'), default: 'success'
 
   * calculation-mode: 'formula' (default) or 'entropy'. Formula is explained below
   * goal: only used in entropy mode. Fixes the amount to reach. Default: 96

--- a/app/src/directive/ng-password-strength.directive.js
+++ b/app/src/directive/ng-password-strength.directive.js
@@ -20,6 +20,9 @@
                 value: '=strength',
                 innerClassPrefix: '@?',
                 outterClassPrefix: '@?',
+                lowStrengthClass: '@?',
+                middleStrengthClass: '@?',
+                highStrengthClass: '@?',
                 innerClass: '@?',
                 cssMode: '@?', // CSS Mode. Can be 'bootstrap' or 'foundation'
                 calculationMode: '@?', // Strength calculation mode. Can be 'formula' or 'entropy'. Default: 'formula' to ensure backwards compatibility
@@ -90,19 +93,19 @@
                     case 0:
                     case 1:
                         return {
-                            outter: scope.outterClassPrefix + 'danger',
-                            inner: scope.innerClassPrefix + 'danger'
+                            outter: scope.outterClassPrefix + scope.lowStrengthClass || 'danger',
+                            inner: scope.innerClassPrefix + scope.lowStrengthClass || 'danger'
                         };
                     case 2:
                         return {
-                            outter: scope.outterClassPrefix + 'warning',
-                            inner: scope.innerClassPrefix + 'warning'
+                            outter: scope.outterClassPrefix + scope.middleStrengthClass || 'warning',
+                            inner: scope.innerClassPrefix + scope.middleStrengthClass || 'warning'
                         };
                     default:
                     // 100 or more
                         return {
-                            outter: scope.outterClassPrefix + 'success',
-                            inner: scope.innerClassPrefix + 'success'
+                            outter: scope.outterClassPrefix + scope.highStrengthClass || 'success',
+                            inner: scope.innerClassPrefix + scope.highStrengthClass || 'success'
                         };
                 }
             }

--- a/app/src/directive/ng-password-strength.directive.js
+++ b/app/src/directive/ng-password-strength.directive.js
@@ -20,9 +20,12 @@
                 value: '=strength',
                 innerClassPrefix: '@?',
                 outterClassPrefix: '@?',
-                lowStrengthClass: '@?',
-                middleStrengthClass: '@?',
-                highStrengthClass: '@?',
+                outterLowStrengthClass: '@?',
+                innerLowStrengthClass: '@?',
+                outterMiddleStrengthClass: '@?',
+                innerMiddleStrengthClass: '@?',
+                outterHighStrengthClass: '@?',
+                innerHighStrengthClass: '@?',
                 innerClass: '@?',
                 cssMode: '@?', // CSS Mode. Can be 'bootstrap' or 'foundation'
                 calculationMode: '@?', // Strength calculation mode. Can be 'formula' or 'entropy'. Default: 'formula' to ensure backwards compatibility
@@ -93,19 +96,19 @@
                     case 0:
                     case 1:
                         return {
-                            outter: scope.outterClassPrefix + scope.lowStrengthClass || 'danger',
-                            inner: scope.innerClassPrefix + scope.lowStrengthClass || 'danger'
+                            outter: scope.outterClassPrefix + scope.outterLowStrengthClass || 'danger',
+                            inner: scope.innerClassPrefix + scope.innerLowStrengthClass || 'danger'
                         };
                     case 2:
                         return {
-                            outter: scope.outterClassPrefix + scope.middleStrengthClass || 'warning',
-                            inner: scope.innerClassPrefix + scope.middleStrengthClass || 'warning'
+                            outter: scope.outterClassPrefix + scope.outterMiddleStrengthClass || 'warning',
+                            inner: scope.innerClassPrefix + scope.innerMiddleStrengthClass || 'warning'
                         };
                     default:
                     // 100 or more
                         return {
-                            outter: scope.outterClassPrefix + scope.highStrengthClass || 'success',
-                            inner: scope.innerClassPrefix + scope.highStrengthClass || 'success'
+                            outter: scope.outterClassPrefix + scope.outterHighStrengthClass || 'success',
+                            inner: scope.innerClassPrefix + scope.innerHighStrengthClass || 'success'
                         };
                 }
             }


### PR DESCRIPTION
Add new addition parameter in order to allow user to set classes used to indicate a low|moderate|high password strength, and not just use the 'danger', 'warning' and 'success' default classes from bootstrap.